### PR TITLE
Added additional constructor for GenericMember

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -125,6 +125,15 @@ public:
     GenericMember& operator=(GenericMember&& rhs) RAPIDJSON_NOEXCEPT {
         return *this = static_cast<GenericMember&>(rhs);
     }
+
+// MB PATCH BEGIN
+    GenericMember(GenericValue<Encoding, Allocator> name, GenericValue<Encoding, Allocator> value) RAPIDJSON_NOEXCEPT
+        : name(std::move(name)),
+          value(std::move(value))
+    {
+    }
+// MB PATCH END
+
 #endif
 
     //! Assignment with move semantics.


### PR DESCRIPTION
Needed for backwards compatibility, class changed in the [commit](https://github.com/microblink/rapidjson/commit/c36b713c47c8255f5a41b0c0053997ff11d95859)